### PR TITLE
Update client.js.twig

### DIFF
--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -154,7 +154,11 @@ class Client {
 
     let cookies = response.headers.getSetCookie();
     if (cookies && cookies.length > 0) {
-      globalConfig.setCookie(cookies[0]);
+      let cookieString = globalConfig.getCookie();
+      cookies.forEach((cookie) => {
+          cookieString += cookie.split(";")[0] + ";";
+      });        
+      globalConfig.setCookie(cookieString);
     }
 
     const text = await response.text();

--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -154,7 +154,7 @@ class Client {
 
     let cookies = response.headers.getSetCookie();
     if (cookies && cookies.length > 0) {
-      let cookieString = globalConfig.getCookie();
+      let cookieString = "";
       cookies.forEach((cookie) => {
           cookieString += cookie.split(";")[0] + ";";
       });        


### PR DESCRIPTION
This change enables appwrite-cli to capture all cookies in 'set-cookie' response headers.

This fixed the issue https://github.com/appwrite/sdk-for-cli/issues/110